### PR TITLE
Add note none-strict triggers instead of logic

### DIFF
--- a/docs/docs/firefly-iii/pages-and-features/search.md
+++ b/docs/docs/firefly-iii/pages-and-features/search.md
@@ -2,7 +2,9 @@
 
 You can search for transactions using the box in the left top of the page. Apart from basic stuff like `Groceries` or `"query with spaces"`, you can also use special operators to search.
 
-You can combine operators like so: `some:operator another:thing` but you can't use `AND` or `OR`. 
+You can combine operators like so: `some:operator another:thing` but you can't use `AND` or `OR`.
+
+Note: If you ended up here, because you want to match multiple descriptions, please check out the none strict matching on triggers.
 
 ## Operators
 


### PR DESCRIPTION
Tried figuring out how to match multiple descriptions at once, and ended up just settling with having to create a rule for each variation...
And then I noticed I can just turn off strict mode to get what I need...
> In strict rules ALL triggers must fire for the action(s) to be executed. In non-strict rules, ANY trigger is enough for the action(s) to be executed.
My wording here isn't great, but it's where I found what I was looking for (even if it was wrong). The current wording let me believe, matching a description with `"Apple" OR "Banana"` isn't possible. But well, it is possible. You just gotta work with a none strict rule.

@JC5
